### PR TITLE
Fix: unused 'stop' function in Player component and add 'use-sound' to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "globals": "^15.14.0",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",
-    "vite": "^6.0.5"
+    "vite": "^6.0.5",
+    "use-sound"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",
     "vite": "^6.0.5",
-    "use-sound"
+    "use-sound": "^4.0.3"
   }
 }

--- a/src/Culture.tsx
+++ b/src/Culture.tsx
@@ -25,10 +25,6 @@ export default function Culture() {
     setActiveTribeContent(tribeContent[id] || "No content available"); // Map id to content or show fallback
   };
 
-  const closePopup = () => {
-    setActiveTribe(null);
-  };
-
   return (
     <div id="culture">
       <div>

--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -4,7 +4,7 @@ import idana from './assets/idana.mp3';
 
 export default function Player() {
   const [isMuted, setIsMuted] = useState<boolean>(false);
-  const [play, { sound, stop }] = useSound(idana, {
+  const [play, { sound }] = useSound(idana, {
     loop: true, // Ensures the song loops
     preload: true, // Preloads the audio file
   });


### PR DESCRIPTION
- Removed the unused 'stop' function to resolve TS6133 error.
- Added 'use-sound' dependency to package.json.